### PR TITLE
Fixing errors when compiling on Mac OS X.

### DIFF
--- a/src/mystl.h
+++ b/src/mystl.h
@@ -5,6 +5,7 @@
 #ifndef MY_STL_H_DEFINED
 #define MY_STL_H_DEFINED
 
+#include <vector>
 #include <string>
 using namespace std;
 #ifdef USE_STLPORT
@@ -296,13 +297,13 @@ void smooth_standard(T*a,T*b,double p)
 }
 
 template<class T>
-const T *conv(typename vector<T>::const_iterator i)
+const T *conv(typename std::vector<T>::const_iterator i)
 {
   return &(*i);
 }
 #if __GNUC__>2
 template<class T>
-T *conv(typename vector<T>::iterator i)
+T *conv(typename std::vector<T>::iterator i)
 {
   return &(*i);
 }


### PR DESCRIPTION
I was getting the following errors before the change.

```
g++ -DHAVE_CONFIG_H -I. -I.. -DPACKAGE_LOCALE_DIR=\""/usr/local//locale"\" -DPACKAGE_SRC_DIR=\""."\" -DPACKAGE_DATA_DIR=\""/usr/local/share"\"  -DNDEBUG -DWORDINDEX_WITH_4_BYTE -DBINARY_SEARCH_FOR_TTABLE -DDEBUG  -Wno-deprecated -Wno-write-strings -I/opt/local/include -MD -MP -MF -MT -O6 -g -O2 -MT libgiza_a-NTables.o -MD -MP -MF .deps/libgiza_a-NTables.Tpo -c -o libgiza_a-NTables.o `test -f 'NTables.cpp' || echo './'`NTables.cpp
In file included from NTables.cpp:22:
In file included from ./NTables.h:24:
In file included from ./Array2.h:31:
./mystl.h:299:24: error: expected a qualified name after 'typename'
const T *conv(typename vector<T>::const_iterator i)
                       ^
./mystl.h:299:24: error: expected a qualified name after 'typename'
./mystl.h:299:30: error: expected ')'
const T *conv(typename vector<T>::const_iterator i)
                             ^
./mystl.h:299:14: note: to match this '('
const T *conv(typename vector<T>::const_iterator i)
             ^
./mystl.h:301:13: error: use of undeclared identifier 'i'
  return &(*i);
            ^
./mystl.h:305:18: error: expected a qualified name after 'typename'
T *conv(typename vector<T>::iterator i)
                 ^
./mystl.h:305:18: error: expected a qualified name after 'typename'
./mystl.h:305:24: error: expected ')'
T *conv(typename vector<T>::iterator i)
                       ^
./mystl.h:305:8: note: to match this '('
T *conv(typename vector<T>::iterator i)
       ^
./mystl.h:307:13: error: use of undeclared identifier 'i'
  return &(*i);
            ^
8 errors generated.
```
